### PR TITLE
Docs: add language support badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
+# Artificial Intelligence for Beginners - A Curriculum
+
 [![GitHub license](https://img.shields.io/github/license/microsoft/AI-For-Beginners.svg)](https://github.com/microsoft/AI-For-Beginners/blob/main/LICENSE)
 [![GitHub contributors](https://img.shields.io/github/contributors/microsoft/AI-For-Beginners.svg)](https://GitHub.com/microsoft/AI-For-Beginners/graphs/contributors/)
 [![GitHub issues](https://img.shields.io/github/issues/microsoft/AI-For-Beginners.svg)](https://GitHub.com/microsoft/AI-For-Beginners/issues/)
 [![GitHub pull-requests](https://img.shields.io/github/issues-pr/microsoft/AI-For-Beginners.svg)](https://GitHub.com/microsoft/AI-For-Beginners/pulls/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+### Language Support
+
+[![German](https://img.shields.io/badge/German-brightgreen.svg?style=flat-square)](./translations/de/README.md)
+[![Spanish](https://img.shields.io/badge/Spanish-brightgreen.svg?style=flat-square)](./translations/es/README.md)
+[![French](https://img.shields.io/badge/French-brightgreen.svg?style=flat-square)](./translations/fr/README.md)
+[![Hindi](https://img.shields.io/badge/Hindi-brightgreen.svg?style=flat-square)](./translations/hi/README.md)
+[![Italian](https://img.shields.io/badge/Italian-brightgreen.svg?style=flat-square)](./translations/it/README.md)
+[![Japanese](https://img.shields.io/badge/Japanese-brightgreen.svg?style=flat-square)](./translations/ja/README.md)
+[![Korean](https://img.shields.io/badge/Korean-brightgreen.svg?style=flat-square)](./translations/ko/README.md)
+[![Malay](https://img.shields.io/badge/Malay-brightgreen.svg?style=flat-square)](./translations/ms/README.md)
+[![Portuguese](https://img.shields.io/badge/Portuguese-brightgreen.svg?style=flat-square)](./translations/pt/README.md)
+[![Russian](https://img.shields.io/badge/Russian-brightgreen.svg?style=flat-square)](./translations/ru/README.md)
+[![Swahili](https://img.shields.io/badge/Swahili-brightgreen.svg?style=flat-square)](./translations/sw/README.md)
+[![Turkish](https://img.shields.io/badge/Turkish-brightgreen.svg?style=flat-square)](./translations/tr/README.md)
+[![Chinese (Simplified)](https://img.shields.io/badge/Chinese_(Simplified)-brightgreen.svg?style=flat-square)](./translations/zh/README.md)
 
 [![GitHub watchers](https://img.shields.io/github/watchers/microsoft/AI-For-Beginners.svg?style=social&label=Watch)](https://GitHub.com/microsoft/AI-For-Beginners/watchers/)
 [![GitHub forks](https://img.shields.io/github/forks/microsoft/AI-For-Beginners.svg?style=social&label=Fork)](https://GitHub.com/microsoft/AI-For-Beginners/network/)
@@ -12,7 +30,6 @@
 
 [![](https://dcbadge.vercel.app/api/server/ByRwuEEgH4)](https://discord.gg/zxKYvhSnVp?WT.mc_id=academic-000002-leestott)
 
-# Artificial Intelligence for Beginners - A Curriculum
 
 |![ Sketchnote by [(@girlie_mac)](https://twitter.com/girlie_mac) ](./lessons/sketchnotes/ai-overview.png)|
 |:---:|


### PR DESCRIPTION
This PR updates `README.md` to include visual badges for supported translation languages.  
The badges link directly to each translated version of the README under `./translations/`.
